### PR TITLE
openssl: added back off when meet server failure 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Examples can be found in [`examples`](./examples).
 - `tls`: Enables the `rustls`-based TLS connection. Not enabled by default.
 - `tls-roots`: Adds system trust roots to `rustls`-based TLS connection using the `rustls-native-certs` crate. Not enabled by default.
 - `pub-response-field`: Exposes structs used to create regular `etcd-client` responses including internal protobuf representations. Useful for mocking. Not enabled by default.
+- `tls-openssl`: Enables the `openssl`-based TLS connections. This would make your binary dynamically link to `libssl`.
+- `tls-openssl-vendored`: Like `tls-openssl`, however compile openssl from source code and statically link to it.
 
 ## Test
 

--- a/src/openssl_tls.rs
+++ b/src/openssl_tls.rs
@@ -132,14 +132,10 @@ where
 }
 
 impl<S> Load for FailBackOff<S> {
-    type Metric = usize;
+    type Metric = bool;
 
     fn load(&self) -> Self::Metric {
-        if self.handle.failed() {
-            0
-        } else {
-            1
-        }
+        self.handle.failed()
     }
 }
 

--- a/src/openssl_tls/backoff.rs
+++ b/src/openssl_tls/backoff.rs
@@ -85,7 +85,7 @@ impl BackOffStatus {
 
 impl BackOffHandle {
     fn fail(&self) {
-        let mut status = Mutex::lock(&self.inner).unwrap();
+        let mut status = self.inner.lock().unwrap();
         status.fail()
     }
 

--- a/src/openssl_tls/backoff.rs
+++ b/src/openssl_tls/backoff.rs
@@ -1,0 +1,158 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::ready,
+    time::{Duration, Instant},
+};
+use tower::{load::Load, Service};
+
+/// FailBackOff is the `Load` implementation for backing off when meet errors.
+/// The general idea is to increase the "load" when a service returns a `Err` variant of some requests.
+/// So normal nodes would have lower load hence easier to be chosen.
+/// The load would be reset after a duration (i.e. after backing off).
+pub struct BackOffWhenFail<S> {
+    inner: S,
+    handle: BackOffHandle,
+}
+
+impl<S> BackOffWhenFail<S> {
+    pub fn new(inner: S, back_off: BackOffStatus) -> Self {
+        Self {
+            inner,
+            handle: BackOffHandle {
+                inner: Arc::new(Mutex::new(back_off)),
+            },
+        }
+    }
+}
+
+#[derive(Clone)]
+struct BackOffHandle {
+    inner: Arc<Mutex<BackOffStatus>>,
+}
+
+#[derive(Clone)]
+pub struct BackOffStatus {
+    initial_backoff_dur: Duration,
+    max_backoff_dur: Duration,
+
+    next_backoff_dur: Duration,
+    last_failure: Option<Instant>,
+}
+
+impl BackOffStatus {
+    pub const fn new(initial: Duration, max: Duration) -> Self {
+        Self {
+            initial_backoff_dur: initial,
+            max_backoff_dur: max,
+
+            next_backoff_dur: initial,
+            last_failure: None,
+        }
+    }
+}
+
+impl BackOffStatus {
+    fn fail(&mut self) {
+        // don't double the back off duration when already failed.
+        // because when a service temporary totally unusable, there might be a flood of failure,
+        // which may make the back off duration too long, even longer than the time it may take to recover.
+        if !self.failed() {
+            self.next_backoff_dur = Ord::min(self.next_backoff_dur * 2, self.max_backoff_dur);
+        }
+        self.last_failure = Some(Instant::now());
+    }
+
+    fn success(&mut self) {
+        self.last_failure = None;
+        self.next_backoff_dur = self.initial_backoff_dur;
+    }
+
+    fn failed(&mut self) -> bool {
+        if let Some(lf) = self.last_failure {
+            if Instant::now().saturating_duration_since(lf) > self.next_backoff_dur {
+                self.last_failure = None;
+            }
+        }
+        self.last_failure.is_some()
+    }
+}
+
+impl BackOffHandle {
+    fn fail(&self) {
+        let mut status = Mutex::lock(&self.inner).unwrap();
+        status.fail()
+    }
+
+    fn failed(&self) -> bool {
+        let mut status = self.inner.lock().unwrap();
+        status.failed()
+    }
+
+    fn success(&self) {
+        let mut status = self.inner.lock().unwrap();
+        status.success()
+    }
+}
+
+pub struct TraceFailFuture<F> {
+    inner: F,
+    handle: BackOffHandle,
+}
+
+impl<F, T, E> Future for TraceFailFuture<F>
+where
+    F: Future<Output = std::result::Result<T, E>>,
+{
+    type Output = <F as Future>::Output;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        // Safety: trivial projection.
+        let (inner, handle) = unsafe {
+            let this = self.get_unchecked_mut();
+            (Pin::new_unchecked(&mut this.inner), &this.handle)
+        };
+
+        let result = ready!(Future::poll(inner, cx));
+        match &result {
+            Ok(_) => handle.success(),
+            Err(_) => handle.fail(),
+        }
+        result.into()
+    }
+}
+
+impl<Req, S> Service<Req> for BackOffWhenFail<S>
+where
+    S: Service<Req>,
+{
+    type Response = <S as Service<Req>>::Response;
+    type Error = <S as Service<Req>>::Error;
+    type Future = TraceFailFuture<<S as Service<Req>>::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::result::Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        TraceFailFuture {
+            inner: self.inner.call(req),
+            handle: self.handle.clone(),
+        }
+    }
+}
+
+impl<S> Load for BackOffWhenFail<S> {
+    type Metric = bool;
+
+    fn load(&self) -> Self::Metric {
+        self.handle.failed()
+    }
+}

--- a/src/openssl_tls/mod.rs
+++ b/src/openssl_tls/mod.rs
@@ -1,0 +1,6 @@
+#![cfg(feature = "tls-openssl")]
+
+mod backoff;
+mod transport;
+
+pub use self::transport::*;

--- a/src/openssl_tls/transport.rs
+++ b/src/openssl_tls/transport.rs
@@ -92,7 +92,7 @@ fn create_openssl_discover<K: Send + 'static>(
             let r = async {
                 match x {
                     Change::Insert(name, e) => {
-                        let chan = e.connect_with_connector(connector.clone().0).await?;
+                        let chan = e.connect_with_connector_lazy(connector.clone().0);
                         Ok(Change::Insert(
                             name,
                             BackOffWhenFail::new(

--- a/src/openssl_tls/transport.rs
+++ b/src/openssl_tls/transport.rs
@@ -1,13 +1,8 @@
 #![cfg(feature = "tls-openssl")]
 
-use std::{
-    future::Future,
-    pin::Pin,
-    sync::{Arc, Mutex},
-    task::ready,
-    time::{Duration, Instant},
-};
+use std::time::Duration;
 
+use super::backoff::{BackOffStatus, BackOffWhenFail};
 use http::{Request, Uri};
 use hyper::client::HttpConnector;
 use hyper_openssl::HttpsConnector;
@@ -23,9 +18,9 @@ use tonic::{
     body::BoxBody,
     transport::{Channel, Endpoint},
 };
-use tower::{balance::p2c::Balance, buffer::Buffer, discover::Change, load::Load, Service};
+use tower::{balance::p2c::Balance, buffer::Buffer, discover::Change};
 
-use super::error::Result;
+use crate::error::Result;
 
 pub type SslConnectorBuilder = openssl::ssl::SslConnectorBuilder;
 pub type OpenSslResult<T> = std::result::Result<T, ErrorStack>;
@@ -36,108 +31,7 @@ pub type Balanced<T> = Balance<T, TonicRequest>;
 pub type OpenSslChannel = Buffered<Balanced<OpenSslDiscover<Uri>>>;
 /// OpenSslDiscover is the backend for balanced channel based on OpenSSL transports.
 /// Because `Channel::balance` doesn't allow us to provide custom connector, we must implement ourselves' balancer...
-pub type OpenSslDiscover<K> = ReceiverStream<Result<Change<K, FailBackOff<Channel>>>>;
-
-pub struct FailBackOff<S> {
-    inner: S,
-    handle: BackOffHandle,
-}
-
-impl<S> FailBackOff<S> {
-    fn new(inner: S, back_off: Duration) -> Self {
-        Self {
-            inner,
-            handle: BackOffHandle {
-                backoff_time: back_off,
-                last_failure: Arc::default(),
-            },
-        }
-    }
-}
-
-#[derive(Clone)]
-struct BackOffHandle {
-    backoff_time: Duration,
-    last_failure: Arc<Mutex<Option<Instant>>>,
-}
-
-impl BackOffHandle {
-    fn fail(&self) {
-        let mut failure = Mutex::lock(&self.last_failure).unwrap();
-        *failure = Some(Instant::now());
-    }
-
-    fn failed(&self) -> bool {
-        let mut failure = self.last_failure.lock().unwrap();
-        if let Some(lf) = failure.as_mut() {
-            if Instant::now().saturating_duration_since(*lf) > self.backoff_time {
-                *failure = None;
-            }
-        }
-
-        failure.is_some()
-    }
-}
-
-pub struct TraceFailFuture<F> {
-    inner: F,
-    handle: BackOffHandle,
-}
-
-impl<F, T, E> Future for TraceFailFuture<F>
-where
-    F: Future<Output = std::result::Result<T, E>>,
-{
-    type Output = <F as Future>::Output;
-
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        // Safety: trivial projection.
-        let (inner, handle) = unsafe {
-            let this = self.get_unchecked_mut();
-            (Pin::new_unchecked(&mut this.inner), &this.handle)
-        };
-
-        let result = ready!(Future::poll(inner, cx));
-        if result.is_err() {
-            handle.fail();
-        }
-        result.into()
-    }
-}
-
-impl<Req, S> Service<Req> for FailBackOff<S>
-where
-    S: Service<Req>,
-{
-    type Response = <S as Service<Req>>::Response;
-    type Error = <S as Service<Req>>::Error;
-    type Future = TraceFailFuture<<S as Service<Req>>::Future>;
-
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<std::result::Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: Req) -> Self::Future {
-        TraceFailFuture {
-            inner: self.inner.call(req),
-            handle: self.handle.clone(),
-        }
-    }
-}
-
-impl<S> Load for FailBackOff<S> {
-    type Metric = bool;
-
-    fn load(&self) -> Self::Metric {
-        self.handle.failed()
-    }
-}
+pub type OpenSslDiscover<K> = ReceiverStream<Result<Change<K, BackOffWhenFail<Channel>>>>;
 
 #[derive(Clone)]
 pub struct OpenSslConnector(HttpsConnector<HttpConnector>);
@@ -201,7 +95,13 @@ fn create_openssl_discover<K: Send + 'static>(
                         let chan = e.connect_with_connector(connector.clone().0).await?;
                         Ok(Change::Insert(
                             name,
-                            FailBackOff::new(chan, Duration::from_secs(30)),
+                            BackOffWhenFail::new(
+                                chan,
+                                BackOffStatus::new(
+                                    /*initial*/ Duration::from_secs(1),
+                                    /*max*/ Duration::from_secs(256),
+                                ),
+                            ),
                         ))
                     }
                     Change::Remove(name) => Ok(Change::Remove(name)),


### PR DESCRIPTION
This PR added a `Load` implement for the openssl implementation. 